### PR TITLE
Add Excel export with configurable column mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,10 @@
 # carlos-proyect
+
+Aplicación sencilla para extraer datos de PDFs de motores y exportarlos a un archivo Excel.
+
+## Uso
+1. **Seleccionar Excel**: elige el archivo de destino donde se guardarán los datos.
+2. **Configurar columnas**: asigna para cada campo la columna correspondiente. Esta configuración se guarda en `column_config.json` para reutilizarse.
+3. **Seleccionar PDF**: carga un PDF y los datos extraídos se muestran en pantalla y se insertan en la primera fila disponible del Excel sin sobrescribir información existente.
+
+Requiere la librería `openpyxl` para manipular archivos `.xlsx`.


### PR DESCRIPTION
## Summary
- allow choosing an Excel workbook and map extracted PDF fields to configurable columns
- persist column mapping in `column_config.json`
- automatically append data to first empty row without overwriting existing values

## Testing
- `python -m py_compile carlo.py`
- `pip install openpyxl` *(fails: Could not find a version that satisfies the requirement openpyxl)*
- `pip install pdfplumber` *(fails: Could not find a version that satisfies the requirement pdfplumber)*
- `python carlo.py` *(fails: ModuleNotFoundError: No module named 'pdfplumber')*

------
https://chatgpt.com/codex/tasks/task_e_68a345ab7afc832b806b034fe51cab02