### PR TITLE
docs: advertir sobre pérdida de drawings con openpyxl

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,5 @@ Aplicación sencilla para extraer datos de PDFs de motores y exportarlos a un ar
 3. **Seleccionar PDF**: carga un PDF y los datos extraídos se muestran en pantalla y se insertan en la primera fila disponible del Excel sin sobrescribir información existente.
 
 Requiere la librería `openpyxl` para manipular archivos `.xlsx`.
+Ten en cuenta que `openpyxl` elimina las shapes o drawings al guardar, por lo que al abrir el archivo Excel mostrará **"Removed Part: /xl/drawings/drawing1.xml"**.
+Si necesitas conservar dichas formas, considera alternativas como `xlwings` o `win32com`.


### PR DESCRIPTION
## Summary
- Advierte que `openpyxl` elimina las shapes/drawings al guardar y que Excel muestra "Removed Part: /xl/drawings/drawing1.xml".
- Sugiere usar `xlwings` o `win32com` si es necesario conservar las formas.

## Testing
- `python -m py_compile carlo.py style_utils.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a3908c4e28832ba3c857936d1fa1cb