### PR TITLE
Gracefully handle missing pdfplumber dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Aplicación sencilla para extraer datos de PDFs de motores y exportarlos a un ar
 2. **Configurar columnas**: asigna para cada campo la columna correspondiente. Esta configuración se guarda en `column_config.json` para reutilizarse.
 3. **Seleccionar PDF**: carga un PDF y los datos extraídos se muestran en pantalla y se insertan en la primera fila disponible del Excel sin sobrescribir información existente.
 
-Requiere la librería `openpyxl` para manipular archivos `.xlsx`.
+Requiere las librerías `openpyxl` para manipular archivos `.xlsx` y
+`pdfplumber` para extraer texto de los PDFs.
 Ten en cuenta que `openpyxl` elimina las shapes o drawings al guardar, por lo que al abrir el archivo Excel mostrará **"Removed Part: /xl/drawings/drawing1.xml"**.
 Si necesitas conservar dichas formas, considera alternativas como `xlwings` o `win32com`.

--- a/carlo.py
+++ b/carlo.py
@@ -1,6 +1,9 @@
 import tkinter as tk
 from tkinter import filedialog, ttk, messagebox
-import pdfplumber
+try:
+    import pdfplumber
+except ModuleNotFoundError:  # pragma: no cover - handled at runtime
+    pdfplumber = None
 import re
 import json
 from openpyxl import load_workbook
@@ -41,6 +44,14 @@ def extraer_datos(pdf_path):
         "Voltage": None,
         "Order Codes": []
     }
+
+    if pdfplumber is None:
+        messagebox.showerror(
+            "Dependencia faltante",
+            "El módulo pdfplumber no está instalado. "
+            "Ejecuta 'pip install pdfplumber' e inténtalo de nuevo.",
+        )
+        return datos
 
     with pdfplumber.open(pdf_path) as pdf:
         text = ""

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+openpyxl
+pdfplumber


### PR DESCRIPTION
## Summary
- avoid crashing when `pdfplumber` is absent by checking import and warning the user
- document `pdfplumber` requirement and add `requirements.txt`

## Testing
- `python -m py_compile carlo.py`
- `python -m py_compile style_utils.py`
- `pip install pdfplumber` *(fails: Could not connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68a392601950832bb2073a4aa144059d