### PR TITLE
Persist Excel path in configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Aplicación sencilla para extraer datos de PDFs de motores y exportarlos a un archivo Excel.
 
 ## Uso
-1. **Seleccionar Excel**: elige el archivo de destino donde se guardarán los datos.
+1. **Seleccionar Excel**: elige el archivo de destino donde se guardarán los datos. La ruta se guarda automáticamente y se reutiliza hasta que el usuario elija un nuevo archivo.
 2. **Configurar columnas**: asigna para cada campo la columna correspondiente. Esta configuración se guarda en `column_config.json` para reutilizarse.
 3. **Seleccionar PDF**: carga un PDF y los datos extraídos se muestran en pantalla y se insertan en la primera fila disponible del Excel sin sobrescribir información existente.
 


### PR DESCRIPTION
## Summary
- load and validate `excel_path` from column configuration
- persist selected Excel file path and column settings
- document automatic reuse of Excel path

## Testing
- `python -m py_compile carlo.py && echo 'PYCOMPILE_OK'`


------
https://chatgpt.com/codex/tasks/task_e_68a49a986a30832b8cb2f9938cdb35af