### PR TITLE
Use configured sheet when writing to Excel

### DIFF
--- a/column_config.json
+++ b/column_config.json
@@ -1,0 +1,13 @@
+{
+  "excel_path": null,
+  "_sheet": null,
+  "columns": {
+    "Catalog Number": "A",
+    "Power (HP)": "B",
+    "Speed (RPM)": "C",
+    "Phase": "D",
+    "Hertz": "E",
+    "Voltage": "F",
+    "Order Codes": "G"
+  }
+}


### PR DESCRIPTION
## Summary
- load and save sheet name in `column_config.json`
- select configured worksheet for writing and row calculation
- document new column configuration structure

## Testing
- `python -m py_compile carlo.py`


------
https://chatgpt.com/codex/tasks/task_e_68a49db32820832bb391dfbd9d77bfb5