### PR TITLE
Add SAP extraction button

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,11 @@ Aplicación sencilla para extraer datos de PDFs de motores y exportarlos a un ar
 ## Uso
 1. **Seleccionar Excel**: elige el archivo de destino donde se guardarán los datos. La ruta se guarda automáticamente y se reutiliza hasta que el usuario elija un nuevo archivo.
 2. **Configurar columnas**: asigna para cada campo la columna correspondiente. Esta configuración se guarda en `column_config.json` para reutilizarse.
-3. **Seleccionar PDF**: carga un PDF y los datos extraídos se muestran en pantalla y se insertan en la primera fila disponible del Excel sin sobrescribir información existente.
+3. **Descargar de SAP**: con el botón *Descargar de SAP* se ejecuta el script `sap_script.py`, que obtiene los documentos desde SAP y los guarda en la ruta definida.
+4. **Seleccionar PDF**: carga un PDF y los datos extraídos se muestran en pantalla y se insertan en la primera fila disponible del Excel sin sobrescribir información existente.
 
-Requiere las librerías `openpyxl` para manipular archivos `.xlsx` y
-`pdfplumber` para extraer texto de los PDFs.
+Requiere las librerías `openpyxl` para manipular archivos `.xlsx`,
+`pdfplumber` para extraer texto de los PDFs y `pyautogui` junto con
+`pywin32` para interactuar con SAP.
 Ten en cuenta que `openpyxl` elimina las shapes o drawings al guardar, por lo que al abrir el archivo Excel mostrará **"Removed Part: /xl/drawings/drawing1.xml"**.
 Si necesitas conservar dichas formas, considera alternativas como `xlwings` o `win32com`.

--- a/carlo.py
+++ b/carlo.py
@@ -9,6 +9,8 @@ import json
 from openpyxl import load_workbook
 from openpyxl.utils import get_column_letter
 import os
+import subprocess
+import sys
 from style_utils import ABB_COLORS, aplicar_colorimetria
 
 CONFIG_FILE = "column_config.json"
@@ -278,6 +280,15 @@ def guardar_en_excel(datos):
     wb.close()
 
 
+def ejecutar_sap():
+    """Ejecuta el script que descarga documentos desde SAP."""
+    try:
+        subprocess.run([sys.executable, "sap_script.py"], check=True)
+        messagebox.showinfo("SAP", "Descarga completada")
+    except Exception as exc:
+        messagebox.showerror("Error SAP", str(exc))
+
+
 def seleccionar_pdf():
     file_path = filedialog.askopenfilename(
         title="Selecciona un archivo PDF",
@@ -314,6 +325,9 @@ btn_excel.pack(pady=5)
 
 btn_config = ttk.Button(root, text="Configurar Columnas", command=configurar_columnas)
 btn_config.pack(pady=5)
+
+btn_sap = ttk.Button(root, text="Descargar de SAP", command=ejecutar_sap)
+btn_sap.pack(pady=5)
 
 btn_cargar = ttk.Button(root, text="Seleccionar PDF", command=seleccionar_pdf)
 btn_cargar.pack(pady=5)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 openpyxl
 pdfplumber
+pyautogui
+pywin32


### PR DESCRIPTION
## Summary
- Add subprocess-based `ejecutar_sap` helper to run `sap_script.py` and button to trigger it from the GUI
- Document SAP download step and dependencies
- List `pyautogui` and `pywin32` in requirements

## Testing
- `python -m py_compile carlo.py sap_script.py`


------
https://chatgpt.com/codex/tasks/task_e_68a5fa377db4832b97d996292ef91902