### PR TITLE
Use absolute path for SAP script

### DIFF
--- a/carlo.py
+++ b/carlo.py
@@ -283,7 +283,8 @@ def guardar_en_excel(datos):
 def ejecutar_sap():
     """Ejecuta el script que descarga documentos desde SAP."""
     try:
-        subprocess.run([sys.executable, "sap_script.py"], check=True)
+        sap_script_path = os.path.join(os.path.dirname(__file__), "sap_script.py")
+        subprocess.run([sys.executable, sap_script_path], check=True)
         messagebox.showinfo("SAP", "Descarga completada")
     except Exception as exc:
         messagebox.showerror("Error SAP", str(exc))


### PR DESCRIPTION
## Summary
- Ensure SAP downloader script is called via an absolute path derived from `__file__`

## Testing
- `python /workspace/carlos-proyect/carlo.py` *(fails: No module named 'openpyxl')*
- `pip install openpyxl` *(fails: Could not find a version that satisfies the requirement openpyxl)*

------
https://chatgpt.com/codex/tasks/task_e_68a5fd80333c832b8841c4bab71a1126