### PR TITLE
Preprocess PDF with Ghostscript before extraction

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 openpyxl
-pdfplumber
+pdfplumber>=0.11.0
 pyautogui
 pywin32


### PR DESCRIPTION
## Summary
- Use Ghostscript to sanitize PDFs before parsing them with pdfplumber
- Require pdfplumber 0.11+ in dependencies

## Testing
- `python -m py_compile carlo.py`
- `gs --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a62cc25aec832ba599917599ba9b29